### PR TITLE
register recent opset_versions 

### DIFF
--- a/onnx2torch/node_converters/identity.py
+++ b/onnx2torch/node_converters/identity.py
@@ -14,6 +14,11 @@ class OnnxCopyIdentity(nn.Module, OnnxToTorchModule):  # pylint: disable=missing
         return x.clone()
 
 
+@add_converter(operation_type='Identity', version=25)
+@add_converter(operation_type='Identity', version=24)
+@add_converter(operation_type='Identity', version=23)
+@add_converter(operation_type='Identity', version=21)
+@add_converter(operation_type='Identity', version=19)
 @add_converter(operation_type='Identity', version=16)
 @add_converter(operation_type='Identity', version=14)
 @add_converter(operation_type='Identity', version=13)

--- a/onnx2torch/node_converters/reshape.py
+++ b/onnx2torch/node_converters/reshape.py
@@ -39,6 +39,11 @@ class OnnxReshape(nn.Module, OnnxToTorchModuleWithCustomExport):  # pylint: disa
 @add_converter(operation_type='Reshape', version=5)
 @add_converter(operation_type='Reshape', version=13)
 @add_converter(operation_type='Reshape', version=14)
+@add_converter(operation_type='Reshape', version=19)
+@add_converter(operation_type='Reshape', version=21)
+@add_converter(operation_type='Reshape', version=23)
+@add_converter(operation_type='Reshape', version=24)
+@add_converter(operation_type='Reshape', version=25)
 def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: disable=unused-argument
     if node.attributes.get('allowzero', 0) == 1:
         raise NotImplementedError('"allowzero=1" is not implemented')

--- a/onnx2torch/node_converters/resize.py
+++ b/onnx2torch/node_converters/resize.py
@@ -123,6 +123,8 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
 
 @add_converter(operation_type='Resize', version=11)
 @add_converter(operation_type='Resize', version=13)
+@add_converter(operation_type='Resize', version=18)
+@add_converter(operation_type='Resize', version=19)
 def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: disable=unused-argument
     node_attributes = node.attributes
     coordinate_transformation_mode = node_attributes.get('coordinate_transformation_mode', 'half_pixel')

--- a/onnx2torch/node_converters/split.py
+++ b/onnx2torch/node_converters/split.py
@@ -57,9 +57,10 @@ class OnnxSplit(nn.Module, OnnxToTorchModule):  # pylint: disable=missing-class-
 
 
 @add_converter(operation_type='Split', version=13)
+@add_converter(operation_type='Split', version=18)
 def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: disable=unused-argument
     axis = node.attributes.get('axis', 0)
-    num_splits = len(node.output_values)
+    num_splits = node.attributes.get('num_outputs', None) or len(node.output_values)
     return OperationConverterResult(
         torch_module=OnnxSplit13(axis=axis, num_splits=num_splits),
         onnx_mapping=onnx_mapping_from_node(node=node),

--- a/onnx2torch/node_converters/transpose.py
+++ b/onnx2torch/node_converters/transpose.py
@@ -30,6 +30,10 @@ class OnnxTranspose(nn.Module, OnnxToTorchModule):  # pylint: disable=missing-cl
 
 @add_converter(operation_type='Transpose', version=1)
 @add_converter(operation_type='Transpose', version=13)
+@add_converter(operation_type='Transpose', version=21)
+@add_converter(operation_type='Transpose', version=23)
+@add_converter(operation_type='Transpose', version=24)
+@add_converter(operation_type='Transpose', version=25)
 def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: disable=unused-argument
     input_values = [node.input_values[0]]
     perm_value_name = node.input_values[1] if len(node.input_values) > 1 else None


### PR DESCRIPTION
## Summary

The model conversion from onnx to coreml is failing in the onnx_to_torch Zetic's fork. Need to add version support for this opset.

`Unacceptable Error: Converter is not implemented (OperationDescription(domain='', operation_type='[op_name]', version=[version_num]))`

## Changes to op:

1. Reshape (v19, v21, v23, v24, v25) `node_converters/reshape.py`

- Previously registered: v5, v13, v14
- [Diff 14→19](https://onnx.ai/onnx/operators/text_diff_Reshape_14_19.html) and [14→21](https://onnx.ai/onnx/operators/text_diff_Reshape_14_21.html): Empty diffs and only type constraint changes

2. Resize (v18, v19) `node_converters/resize.py`

- Previously registered: v10, v11, v13
- [Diff 13→19](https://onnx.ai/onnx/operators/text_diff_Resize_13_19.html) v18 added optional attributes antialias, axes, keep_aspect_ratio_policy but all have safe defaults matching existing behavior. v19 made roi/scales inputs optional (the existing converter already handles them as optional by checking nelement() != 0). Core interpolation logic is identical. The new attributes are silently ignored by node_attributes.get() when not present.

3. Identity (v19, v21, v23, v24, v25) `node_converters/identity.py`

- Previously registered: v1, v13, v14, v16
- [Diff 14→21](https://onnx.ai/onnx/operators/text_diff_Identity_14_21.html): Empty diff, only type constraints expanded.

4. Split (v18) `node_converters/split.py`

- Previously registered: v2, v11, v13. v18 adds optional attribute num_outputs
- [Diff 13→18](https://onnx.ai/onnx/operators/text_diff_Split_13_18.html) When present we use it for num_splits, otherwise we use len(node.output_values) (v13 behavior). No additional constraints.

5. When comparing transpose 13 vs 21, only the constraints differ as seen in: https://onnx.ai/onnx/operators/text_diff_Transpose_13_21.html