### PR TITLE
feat: add IsNaN op version 9 and 20 support

### DIFF
--- a/onnx2torch/node_converters/isnan.py
+++ b/onnx2torch/node_converters/isnan.py
@@ -19,7 +19,12 @@ class OnnxIsNaN(nn.Module, OnnxToTorchModule):
         return torch.isnan(input_tensor)
 
 
+# version 9:  T1 in (float16, float, double)
+# version 13: T1 adds bfloat16
+# version 20: T1 adds float8e4m3fn, float8e4m3fnuz, float8e5m2, float8e5m2fnuz
+@add_converter(operation_type='IsNaN', version=9)
 @add_converter(operation_type='IsNaN', version=13)
+@add_converter(operation_type='IsNaN', version=20)
 def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:
     del graph
     torch_module = OnnxIsNaN()


### PR DESCRIPTION
## Summary

Add ONNX IsNaN operator version 9 and 20 support (version 13 was already supported).

## Changes

All three versions share the same converter function since only the type constraints differ:

| Version | Type Constraints (T1) |
|---------|----------------------|
| **9**   | float16, float, double |
| **13**  | + bfloat16 |
| **20**  | + float8e4m3fn, float8e4m3fnuz, float8e5m2, float8e5m2fnuz |

Verified that `torch.isnan` supports all of the above dtypes.

## Files Changed

- `onnx2torch/node_converters/isnan.py`: Added `@add_converter` decorators for version 9 and 20, with comments documenting per-version type constraint changes.