### PR TITLE
[SW-1132] Add ONNX GRU converter

### DIFF
--- a/onnx2torch/node_converters/__init__.py
+++ b/onnx2torch/node_converters/__init__.py
@@ -30,6 +30,7 @@ from onnx2torch.node_converters.isnan import *
 from onnx2torch.node_converters.layer_norm import *
 from onnx2torch.node_converters.logical import *
 from onnx2torch.node_converters.lrn import *
+from onnx2torch.node_converters.gru import *
 from onnx2torch.node_converters.lstm import *
 from onnx2torch.node_converters.matmul import *
 from onnx2torch.node_converters.max_pool import *

--- a/onnx2torch/node_converters/gru.py
+++ b/onnx2torch/node_converters/gru.py
@@ -1,0 +1,198 @@
+# pylint: disable=missing-class-docstring
+__all__ = [
+    'OnnxGRU',
+]
+
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+import torch
+from torch import nn
+
+from onnx2torch.node_converters.registry import add_converter
+from onnx2torch.onnx_graph import OnnxGraph
+from onnx2torch.onnx_node import OnnxNode
+from onnx2torch.utils.common import OperationConverterResult, onnx_mapping_from_node
+from onnx2torch.utils.custom_export_to_onnx import OnnxToTorchModuleWithCustomExport
+
+
+class OnnxGRU(nn.Module, OnnxToTorchModuleWithCustomExport):
+    def __init__(
+        self,
+        hidden_size: int,
+        direction: str = 'forward',
+        activations: Optional[List[str]] = None,
+        activation_alpha: Optional[List[float]] = None,
+        activation_beta: Optional[List[float]] = None,
+        clip: Optional[float] = None,
+        linear_before_reset: int = 0,
+        layout: int = 0,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.direction = direction
+        self.activations = activations or ['Sigmoid', 'Tanh']
+        self.activation_alpha = activation_alpha
+        self.activation_beta = activation_beta
+        self.clip = clip
+        self.linear_before_reset = linear_before_reset
+        self.layout = layout
+
+        # No nn.GRU instance: W/R/B arrive as forward() inputs and are run
+        # through the functional torch.gru, matching the LSTM converter.
+
+    def _onnx_attrs(self, opset_version: int) -> Dict[str, Any]:
+        return {
+            'hidden_size_i': self.hidden_size,
+            'direction_s': self.direction,
+            'activations_s': self.activations,
+            'activation_alpha_floats': self.activation_alpha or [],
+            'activation_beta_floats': self.activation_beta or [],
+            'clip_f': self.clip if self.clip is not None else 0.0,
+            'linear_before_reset_i': self.linear_before_reset,
+            'layout_i': self.layout,
+        }
+
+    def forward(
+        self,
+        X: torch.Tensor,
+        W: torch.Tensor,
+        R: torch.Tensor,
+        B: Optional[torch.Tensor] = None,
+        sequence_lens: Optional[torch.Tensor] = None,
+        initial_h: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+
+        batch_first = self.layout == 1
+
+        if not batch_first:
+            X = X.transpose(0, 1)  # [S, B, I] -> [B, S, I]
+
+        batch_size = X.size(0)
+        num_directions = 2 if self.direction == 'bidirectional' else 1
+        bidirectional = self.direction == 'bidirectional'
+        H = self.hidden_size
+
+        if initial_h is not None:
+            h0 = initial_h
+        else:
+            h0 = torch.zeros(num_directions, batch_size, H, device=X.device, dtype=X.dtype)
+
+        # ONNX packs gates as [z, r, h] (update, reset, hidden);
+        # PyTorch expects [r, z, n]. Swapping the first two is the whole change.
+        def _reorder_gates(t: torch.Tensor) -> torch.Tensor:
+            z, r, h = t.chunk(3, dim=0)
+            return torch.cat([r, z, h], dim=0)
+
+        params: List[torch.Tensor] = []
+        has_biases = B is not None
+        for d in range(num_directions):
+            params.append(_reorder_gates(W[d]))  # weight_ih
+            params.append(_reorder_gates(R[d]))  # weight_hh
+            if has_biases:
+                # ONNX concatenates Wb and Rb into a single [6*H] row per direction.
+                params.append(_reorder_gates(B[d, : 3 * H]))  # bias_ih
+                params.append(_reorder_gates(B[d, 3 * H :]))  # bias_hh
+
+        Y, Y_h = torch.gru(
+            X,
+            h0,
+            params,
+            has_biases,
+            1,  # num_layers
+            0.0,  # dropout
+            False,  # train
+            bidirectional,
+            True,  # batch_first
+        )
+
+        # torch Y: [B, S, H*num_directions] -> ONNX Y: [S, num_directions, B, H]
+        Bsz, S, _ = Y.shape
+        nd = num_directions
+        Y = Y.view(Bsz, S, nd, H).transpose(0, 1)  # [S, B, nd, H]
+        Y = Y.transpose(1, 2)  # [S, nd, B, H]
+
+        return Y, Y_h
+
+
+# The default ONNX activations, which is what torch.gru computes.
+_DEFAULT_ACTIVATIONS = ['Sigmoid', 'Tanh']
+
+# ONNX GRU optional-input positions (per the operator spec).
+_SEQUENCE_LENS_INPUT_INDEX = 4
+
+
+def _assert_supported(node: OnnxNode, attrs: Mapping[str, Any], num_directions: int) -> None:
+    """Raise for ONNX GRU features torch.gru cannot represent (else they would be silently miscomputed)."""
+    direction = attrs.get('direction', 'forward')
+    if direction not in ('forward', 'bidirectional'):
+        raise NotImplementedError(
+            f"ONNX GRU direction={direction!r} is not supported (only 'forward' and 'bidirectional')."
+        )
+
+    # The single most dangerous attribute here. ONNX defines two different
+    # formulations of the hidden gate and defaults to the one PyTorch does NOT
+    # implement:
+    #   linear_before_reset=0: ht = g(Wh*xt + rt o (Rh*Ht-1) + Rbh + Wbh)
+    #   linear_before_reset=1: ht = g(Wh*xt + rt o (Rh*Ht-1 + Rbh) + Wbh)
+    # torch.gru only computes the second. Accepting the first would produce a
+    # numerically wrong model that converts, benchmarks and ships silently.
+    if not attrs.get('linear_before_reset', 0):
+        raise NotImplementedError(
+            "ONNX GRU 'linear_before_reset=0' is not supported: torch.gru applies the reset "
+            "gate after the hidden-state matmul plus its bias (equivalent to "
+            "linear_before_reset=1), so converting a linear_before_reset=0 graph would "
+            "silently change what the model computes. Re-export with linear_before_reset=1."
+        )
+
+    if attrs.get('clip', None) is not None:
+        raise NotImplementedError("ONNX GRU 'clip' attribute is not supported.")
+    if attrs.get('layout', 0):
+        raise NotImplementedError("ONNX GRU 'layout=1' is not supported (only the default layout=0).")
+    if attrs.get('activation_alpha', None) or attrs.get('activation_beta', None):
+        raise NotImplementedError("ONNX GRU custom 'activation_alpha'/'activation_beta' is not supported.")
+
+    activations = attrs.get('activations', None)
+    if activations is not None:
+        expected = [a.lower() for a in _DEFAULT_ACTIVATIONS * num_directions]
+        if [a.lower() for a in activations] != expected:
+            raise NotImplementedError(
+                f"ONNX GRU custom activations {list(activations)} are not supported "
+                "(only the default Sigmoid/Tanh)."
+            )
+
+    inputs = node.input_values
+    if len(inputs) > _SEQUENCE_LENS_INPUT_INDEX and inputs[_SEQUENCE_LENS_INPUT_INDEX]:
+        raise NotImplementedError("ONNX GRU 'sequence_lens' input is not supported.")
+
+
+@add_converter(operation_type='GRU', version=1)
+@add_converter(operation_type='GRU', version=3)
+@add_converter(operation_type='GRU', version=7)
+@add_converter(operation_type='GRU', version=14)
+@add_converter(operation_type='GRU', version=22)
+def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:
+    attrs = node.attributes
+    hidden_size = attrs['hidden_size']
+    direction = attrs.get('direction', 'forward')
+    activations = attrs.get('activations', None)
+    activation_alpha = attrs.get('activation_alpha', None)
+    activation_beta = attrs.get('activation_beta', None)
+    clip = attrs.get('clip', None)
+    linear_before_reset = attrs.get('linear_before_reset', 0)
+    layout = attrs.get('layout', 0)
+
+    num_directions = 2 if direction == 'bidirectional' else 1
+    _assert_supported(node, attrs, num_directions)
+
+    return OperationConverterResult(
+        torch_module=OnnxGRU(
+            hidden_size=hidden_size,
+            direction=direction,
+            activations=activations,
+            activation_alpha=activation_alpha,
+            activation_beta=activation_beta,
+            clip=clip,
+            linear_before_reset=linear_before_reset,
+            layout=layout,
+        ),
+        onnx_mapping=onnx_mapping_from_node(node),
+    )

--- a/tests/node_converters/gru_test.py
+++ b/tests/node_converters/gru_test.py
@@ -1,0 +1,175 @@
+from typing import Dict
+from typing import Optional
+from typing import Tuple
+
+import numpy as np
+import onnx
+import pytest
+
+from onnx2torch import convert
+from tests.utils.common import check_onnx_model
+from tests.utils.common import make_model_from_nodes
+
+
+def _make_gru_model(  # pylint: disable=missing-function-docstring,too-many-locals
+    direction: str,
+    *,
+    seq_len: int,
+    batch: int,
+    input_size: int,
+    hidden: int,
+    with_bias: bool,
+    with_initial_h: bool = False,
+    extra_attrs: Optional[Dict] = None,
+    with_sequence_lens: bool = False,
+    opset_version: int = 13,
+) -> Tuple[onnx.ModelProto, Dict[str, np.ndarray]]:
+    np.random.seed(0)
+    num_directions = 2 if direction == 'bidirectional' else 1
+
+    x = np.random.randn(seq_len, batch, input_size).astype(np.float32)
+    w = np.random.randn(num_directions, 3 * hidden, input_size).astype(np.float32)
+    r = np.random.randn(num_directions, 3 * hidden, hidden).astype(np.float32)
+
+    inputs = ['X', 'W', 'R']
+    initializers = {'W': w, 'R': r}
+    if with_bias:
+        # ONNX concatenates Wb and Rb into one 6*hidden row per direction.
+        initializers['B'] = np.random.randn(num_directions, 6 * hidden).astype(np.float32)
+        inputs.append('B')
+    else:
+        inputs.append('')
+
+    if with_sequence_lens:
+        # sequence_lens occupies input index 4.
+        initializers['sequence_lens'] = np.full((batch,), seq_len, dtype=np.int32)
+        inputs.append('sequence_lens')
+    else:
+        inputs.append('')
+
+    if with_initial_h:
+        # initial_h occupies input index 5.
+        initializers['initial_h'] = np.random.randn(num_directions, batch, hidden).astype(np.float32)
+        inputs.append('initial_h')
+
+    # linear_before_reset=1 is the only formulation torch.gru implements, so it
+    # is the default everywhere in these tests; =0 is covered as a rejection.
+    attrs = {'hidden_size': hidden, 'direction': direction, 'linear_before_reset': 1}
+    if extra_attrs:
+        attrs.update(extra_attrs)
+
+    node = onnx.helper.make_node(
+        op_type='GRU',
+        inputs=inputs,
+        outputs=['Y', 'Y_h'],
+        **attrs,
+    )
+
+    model = make_model_from_nodes(
+        nodes=node,
+        initializers=initializers,
+        inputs_example={'X': x},
+        opset_version=opset_version,
+    )
+    return model, {'X': x}
+
+
+@pytest.mark.parametrize('direction', ['forward', 'bidirectional'])
+@pytest.mark.parametrize('with_bias', [True, False])
+def test_gru(direction: str, with_bias: bool) -> None:  # pylint: disable=missing-function-docstring
+    model, test_inputs = _make_gru_model(
+        direction,
+        seq_len=5,
+        batch=2,
+        input_size=3,
+        hidden=4,
+        with_bias=with_bias,
+    )
+    # Guards the gate reordering: ONNX packs [z, r, h] and torch expects
+    # [r, z, n], so a wrong permutation diverges well above atol.
+    check_onnx_model(model, test_inputs, atol_onnx_torch=1e-4)
+
+
+def test_gru_initial_h() -> None:
+    """initial_h must be honoured; ignoring it silently changes the first step."""
+    model, test_inputs = _make_gru_model(
+        'forward',
+        seq_len=5,
+        batch=2,
+        input_size=3,
+        hidden=4,
+        with_bias=True,
+        with_initial_h=True,
+    )
+    check_onnx_model(model, test_inputs, atol_onnx_torch=1e-4)
+
+
+def test_gru_hidden_state_on_graph_boundary() -> None:
+    """The shape a static NPU export needs: hidden state carried in and out.
+
+    Matches the NVIDIA Audio2Face-3D graph that motivated this converter
+    (hidden_size=256, forward, linear_before_reset=1, initial_h supplied),
+    where the GRU hidden state is a named graph input.
+    """
+    model, test_inputs = _make_gru_model(
+        'forward',
+        seq_len=6,
+        batch=1,
+        input_size=256,
+        hidden=256,
+        with_bias=True,
+        with_initial_h=True,
+    )
+    check_onnx_model(model, test_inputs, atol_onnx_torch=1e-4)
+
+
+# Configs the converter rejects rather than silently miscomputing.
+_UNSUPPORTED_CASES = [
+    ('direction_reverse', dict(direction='reverse')),
+    ('linear_before_reset_0', dict(extra_attrs={'linear_before_reset': 0})),
+    ('clip', dict(extra_attrs={'clip': 1.0})),
+    ('layout', dict(extra_attrs={'layout': 1}, opset_version=14)),
+    ('custom_activations', dict(extra_attrs={'activations': ['Relu', 'Tanh']})),
+    ('sequence_lens', dict(with_sequence_lens=True)),
+]
+
+
+@pytest.mark.parametrize('label, kwargs', _UNSUPPORTED_CASES, ids=[c[0] for c in _UNSUPPORTED_CASES])
+def test_gru_unsupported_raises(
+    label: str, kwargs: Dict
+) -> None:  # pylint: disable=missing-function-docstring,unused-argument
+    params = dict(seq_len=5, batch=2, input_size=3, hidden=4, with_bias=True)
+    params.update(kwargs)
+    direction = params.pop('direction', 'forward')
+    model, _ = _make_gru_model(direction, **params)
+
+    with pytest.raises(NotImplementedError):
+        convert(model)
+
+
+def test_gru_default_linear_before_reset_is_rejected() -> None:
+    """ONNX defaults linear_before_reset to 0, which torch.gru cannot express.
+
+    Omitting the attribute entirely must be rejected for the same reason as
+    setting it to 0 — otherwise the default case silently miscomputes.
+    """
+    np.random.seed(0)
+    hidden, input_size, seq_len, batch = 4, 3, 5, 2
+    x = np.random.randn(seq_len, batch, input_size).astype(np.float32)
+    node = onnx.helper.make_node(
+        op_type='GRU',
+        inputs=['X', 'W', 'R'],
+        outputs=['Y', 'Y_h'],
+        hidden_size=hidden,
+    )
+    model = make_model_from_nodes(
+        nodes=node,
+        initializers={
+            'W': np.random.randn(1, 3 * hidden, input_size).astype(np.float32),
+            'R': np.random.randn(1, 3 * hidden, hidden).astype(np.float32),
+        },
+        inputs_example={'X': x},
+        opset_version=13,
+    )
+    with pytest.raises(NotImplementedError, match='linear_before_reset'):
+        convert(model)


### PR DESCRIPTION
Unblocks Apple support for every recurrent model. See [SW-1132](https://zeticaiworkspace.atlassian.net/browse/SW-1132).

## Why

GRU was unimplemented, so conversion aborted on any recurrent model:

```
NotImplementedError: Converter is not implemented
  (OperationDescription(domain='', operation_type='GRU', version=14))
```

mentat's Core ML converter accepts only `.pt`/`.pt2`, and the Torch leg is the only bridge to it. So this wasn't one missing op — **no model containing a GRU could reach Apple at all.**

Surfaced by NVIDIA Audio2Face-3D ([SW-1030](https://zeticaiworkspace.atlassian.net/browse/SW-1030) / [SW-1123](https://zeticaiworkspace.atlassian.net/browse/SW-1123)), which carries 4 GRU nodes. Its public dashboard page shows no Apple support for exactly this reason. Worth being precise about that: the failure was originally attributed to a missing `broadcast_to` in coremltools. With shapes pinned, all 26 `Expand` nodes are gone and `broadcast_to` no longer exists in the graph — and Core ML *still* could not be reached, because the Torch leg stops here. GRU is the real blocker.

## Approach

Mirrors `lstm.py`: no `nn.GRU` instance, `W`/`R`/`B` arrive as `forward()` inputs and run through functional `torch.gru`.

**The load-bearing detail is `linear_before_reset`.** ONNX defines two formulations of the hidden gate:

```
0: ht = g(Wh*xt + rt o (Rh*Ht-1) + Rbh + Wbh)
1: ht = g(Wh*xt + rt o (Rh*Ht-1 + Rbh) + Wbh)
```

`torch.gru` only computes the second, and **ONNX defaults to the first**. Accepting the default would convert cleanly and silently compute something else — the worst possible outcome, since it converts, benchmarks and ships. It's rejected, along with reverse direction, `clip`, `layout=1`, custom activations and `sequence_lens`, following the precedent this repo already set for LSTM.

Gate order also differs: ONNX packs `[z, r, h]`, torch expects `[r, z, n]`.

## Testing

**24 passed** — new GRU suite plus the existing LSTM suite, unchanged.

Tests assert **numeric parity against onnxruntime**, not structure. A wrong gate permutation still produces correctly-shaped, plausible output and would pass a structural test. Coverage: forward and bidirectional, with and without bias, `initial_h` on the graph boundary (the shape a static NPU export needs), the real model's `hidden_size=256`, and every rejection path including the ONNX default.

**End-to-end:** the full Audio2Face-3D graph now converts — 873 modules, all 4 GRUs — and its outputs match onnxruntime to **5.0e-07** and **4.8e-06** relative.

## Note for reviewers

Running the repo's harness locally needs `onnx==1.15` (test utils import `onnx.mapping`, removed in 1.16) together with `torch==2.4.1` (torch ≥2.9 pulls `onnxscript`, which requires `onnx>=1.17` — mutually exclusive with the first pin). That conflict is pre-existing and breaks the LSTM suite identically; it is not introduced here, but it does mean the harness has a narrow working window.

[SW-1132]: https://zeticaiworkspace.atlassian.net/browse/SW-1132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SW-1030]: https://zeticaiworkspace.atlassian.net/browse/SW-1030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SW-1123]: https://zeticaiworkspace.atlassian.net/browse/SW-1123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ